### PR TITLE
fix translations path on install command

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -22,7 +22,7 @@ class Install extends Command
     public function handle()
     {
         $this->call('cashier:install', ['--template' => true]);
-        $this->call('translations:add', ['path' => 'vendor/typicms/subscriptions/src/resources/lang']);
+        $this->call('translations:add', ['path' => 'vendor/typicms/subscriptions/resources/lang']);
         $this->call('notifications:table');
         $this->call('vendor:publish', [
             '--provider' => 'TypiCMS\Modules\Subscriptions\Providers\ModuleServiceProvider',


### PR DESCRIPTION
When running the install command there was this error 
```vendor/typicms/subscriptions/src/resources/lang is not a file or a directory.```
